### PR TITLE
added platform flag to allow m1 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Note: we nvidia/cuda such that this same image can be used for DL projects.
 # If you don't need CUDA, you should a base image that is smaller like python:3.8-slim
-FROM nvidia/cuda:11.7.1-base-ubuntu20.04
+FROM --platform=linux/amd64 nvidia/cuda:11.7.1-base-ubuntu20.04
 
 # Gather the required apt-get images
 RUN apt-get -y update \


### PR DESCRIPTION
With this flag in the dockerfile it is now possible to also build the image on M1 Macs